### PR TITLE
Adding a way for tests to stop if not in the correct environment (and adding test db to dev container)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,10 +27,25 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: cnlearn
       POSTGRES_PASSWORD: postgres
-      TESTING: Development
+      ENVIRONMENT: Development
+    ports:
+      - 5432:5432
 
+  testing_db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data-testing:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: cnlearn_testing
+      POSTGRES_PASSWORD: postgres
+      ENVIRONMENT: Testing
+    ports:
+      - 5433:5432
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:
   postgres-data:
+  postgres-data-testing:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from typing import AsyncGenerator, Awaitable, Callable, Generator, Optional
 
 import pytest
@@ -16,9 +17,17 @@ from app.schemas.user import UserCreate
 from app.settings.base import settings
 
 
+# if the wrong environment, stop tests
+@pytest.fixture(scope="session", autouse=True)
+def check_environment() -> Generator[None, None, None]:
+    if os.getenv("ENVIRONMENT") != "Testing":
+        raise Exception("Tests can only be run in a testing environment")
+    yield
+
+
 # Apply migrations at beginning and end of testing session
 @pytest.fixture(scope="session")
-def apply_migrations() -> Generator[None, None, None]:
+def apply_migrations(check_environment: Callable[[None], None]) -> Generator[None, None, None]:
     config = Config("alembic.ini")
     alembic.command.upgrade(config, "head")
     yield


### PR DESCRIPTION
If not in the right environment, (i.e. ENVIRONMENT=Testing), tests should stop.